### PR TITLE
Fix chunk to reject non-positive size

### DIFF
--- a/packages/workflow/src/Extensions/ArrayExtensions.ts
+++ b/packages/workflow/src/Extensions/ArrayExtensions.ts
@@ -166,10 +166,10 @@ function smartJoin(value: unknown[], extraArgs: string[]): object {
 }
 
 function chunk(value: unknown[], extraArgs: number[]) {
-	const [chunkSize] = extraArgs;
-	if (typeof chunkSize !== 'number' || chunkSize === 0) {
-		throw new ExpressionExtensionError('chunk(): expected non-zero numeric arg, e.g. .chunk(5)');
-	}
+        const [chunkSize] = extraArgs;
+        if (typeof chunkSize !== 'number' || chunkSize <= 0) {
+                throw new ExpressionExtensionError('chunk(): expected a positive numeric arg, e.g. .chunk(5)');
+        }
 	const chunks: unknown[][] = [];
 	for (let i = 0; i < value.length; i += chunkSize) {
 		// I have no clue why eslint thinks 2 numbers could be anything but that but here we are

--- a/packages/workflow/test/ExpressionExtensions/ArrayExtensions.test.ts
+++ b/packages/workflow/test/ExpressionExtensions/ArrayExtensions.test.ts
@@ -239,14 +239,23 @@ describe('Data Transformation Functions', () => {
 			).toEqual([{ test1: 1 }, 1, 2, 0, { test: 'asdf' }]);
 		});
 
-		test('.chunk() should work on an array', () => {
-			expect(evaluate('={{ numberList(1, 20).chunk(5) }}')).toEqual([
-				[1, 2, 3, 4, 5],
-				[6, 7, 8, 9, 10],
-				[11, 12, 13, 14, 15],
-				[16, 17, 18, 19, 20],
-			]);
-		});
+                test('.chunk() should work on an array', () => {
+                        expect(evaluate('={{ numberList(1, 20).chunk(5) }}')).toEqual([
+                                [1, 2, 3, 4, 5],
+                                [6, 7, 8, 9, 10],
+                                [11, 12, 13, 14, 15],
+                                [16, 17, 18, 19, 20],
+                        ]);
+                });
+
+                test('.chunk() should throw for non-positive chunk size', () => {
+                        expect(() => evaluate('={{ [1,2,3].chunk(0) }}')).toThrow(
+                                'chunk(): expected a positive numeric arg, e.g. .chunk(5)',
+                        );
+                        expect(() => evaluate('={{ [1,2,3].chunk(-1) }}')).toThrow(
+                                'chunk(): expected a positive numeric arg, e.g. .chunk(5)',
+                        );
+                });
 
 		test('.toJsonString() should work on an array', () => {
 			expect(evaluate('={{ [true, 1, "one", {foo: "bar"}].toJsonString() }}')).toEqual(


### PR DESCRIPTION
## Summary
- prevent infinite loops with negative chunk sizes
- test chunk size validation

## Testing
- `pnpm test` *(fails: unable to fetch pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_684099f8862c8325a9e036b6870d96f8